### PR TITLE
Change connection type from <any> to <boolean | null>

### DIFF
--- a/client/src/components/Connection/Connection.tsx
+++ b/client/src/components/Connection/Connection.tsx
@@ -8,7 +8,7 @@ import { green, yellow, red } from '@mui/material/colors'
 
 const Connection: FC = () => {
 
-    const [ connection, setConnection ] = useState<any>(null)
+    const [ connection, setConnection ] = useState<boolean | null>(null)
 
     useEffect(() => {
         const id = setInterval(() => getConnection(setConnection), 10000);

--- a/client/src/queries/connection.ts
+++ b/client/src/queries/connection.ts
@@ -1,6 +1,6 @@
 import { get } from "./fetch";
 
-export const getConnection = ( callback: React.Dispatch<React.SetStateAction<boolean>> ) => {
+export const getConnection = ( callback: React.Dispatch<React.SetStateAction<boolean | null>> ) => {
     get('/connection', (connection: boolean) => {
         console.log("Connection:\n");
         console.log(connection);


### PR DESCRIPTION
Changed the connection indicator type from any to boolean or null and change the callback of getConnection.