### PR TITLE
Change import method for knex, to get more typing

### DIFF
--- a/server-nest/src/main.ts
+++ b/server-nest/src/main.ts
@@ -1,7 +1,8 @@
 import { NestFactory } from '@nestjs/core';
+import { knex } from 'knex'
 import { AppModule } from './app.module';
 
-const pg = require('knex')({
+const pg = knex({
   client: 'pg',
   connection: {
     host : 'se2-e.compute.dtu.dk',


### PR DESCRIPTION
Before I imported Knex as they do in the tutorial with 
```
pg = require('knex')({<db_config>})
```

However, this way of doing it, meant that the type was not derived for the pg object, so you couldn't see what methods and properties was available on it. This new way, we get that information. 